### PR TITLE
Add support for headers

### DIFF
--- a/lua/daedalus/init.lua
+++ b/lua/daedalus/init.lua
@@ -70,6 +70,13 @@ daedalus.call = function(opt)
     table.insert(cmd, opt.encode(opt.payload))
   end
 
+  if opt.headers ~= nil then
+    for k, v in pairs(opt.headers) do
+      table.insert(cmd, "-H")
+      table.insert(cmd, k..': '..v)
+    end
+  end
+
   local url = opt.url
   if opt.urlargs ~= nil then
     url = interpolate(url, opt.urlargs)


### PR DESCRIPTION
Allows you to add headers to the request. For example:

```lua
headers = {
  ["Content-Type"] = "application/json",
}
```