### PR TITLE
Adds support for curl's basic auth `-u` flag and a helper function

### DIFF
--- a/lua/daedalus/helpers.lua
+++ b/lua/daedalus/helpers.lua
@@ -6,5 +6,8 @@ helpers.auth.bearer = function(token)
   return "Bearer " .. vim.fn.expand(token)
 end
 
+helpers.auth.basic = function(user, pass)
+  return vim.fn.expand(user)..':'..vim.fn.expand(pass)
+end
 
 return helpers

--- a/lua/daedalus/init.lua
+++ b/lua/daedalus/init.lua
@@ -65,6 +65,11 @@ daedalus.call = function(opt)
     table.insert(cmd, "Authorization: " .. opt.auth)
   end
 
+  if opt.auth_basic ~= nil then
+    table.insert(cmd, "-u")
+    table.insert(cmd, opt.auth_basic)
+  end
+
   if opt.payload ~= nil then
     table.insert(cmd, "-d")
     table.insert(cmd, opt.encode(opt.payload))

--- a/lua/daedalus/init.lua
+++ b/lua/daedalus/init.lua
@@ -65,9 +65,9 @@ daedalus.call = function(opt)
     table.insert(cmd, "Authorization: " .. opt.auth)
   end
 
-  if opt.auth_basic ~= nil then
+  if opt.basic_auth ~= nil then
     table.insert(cmd, "-u")
-    table.insert(cmd, opt.auth_basic)
+    table.insert(cmd, opt.basic_auth)
   end
 
   if opt.payload ~= nil then


### PR DESCRIPTION
Allows a user to use basic authentication for the request. 

There might be a better way to name it other than `basic_auth` but plain `auth` was already taken.